### PR TITLE
Fixed the javadoc on getJobsInfo(). 

### DIFF
--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -1183,7 +1183,7 @@ public class OozieClient {
     /**
      * Return the info of the workflow jobs that match the filter.
      * <p/>
-     * It returns the first 100 jobs that match the filter.
+     * It returns the first 50 jobs that match the filter.
      *
      * @param filter job filter. Refer to the {@link OozieClient} for the filter syntax.
      * @return a list with the workflow jobs info, without node details.


### PR DESCRIPTION
Defaults to 50, not 100, results.
