### PR TITLE
Add feature to let user configure ssh port in oozie-site.xml while run ssh

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/ssh/SshActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/ssh/SshActionExecutor.java
@@ -60,9 +60,11 @@ public class SshActionExecutor extends ActionExecutor {
 
     protected static final String SSH_COMMAND_OPTIONS =
             "-o PasswordAuthentication=no -o KbdInteractiveDevices=no -o StrictHostKeyChecking=no -o ConnectTimeout=20 ";
+    
+    public static final String COMMAND_BASE_PORT = "oozie.action.ssh.command.port";
 
-    protected static final String SSH_COMMAND_BASE = "ssh " + SSH_COMMAND_OPTIONS;
-    protected static final String SCP_COMMAND_BASE = "scp " + SSH_COMMAND_OPTIONS;
+    protected static String SSH_COMMAND_BASE = "ssh -p ";
+    protected static String SCP_COMMAND_BASE = "scp -P ";
 
     public static final String ERR_SETUP_FAILED = "SETUP_FAILED";
     public static final String ERR_EXECUTION_FAILED = "EXECUTION_FAILED";
@@ -98,6 +100,11 @@ public class SshActionExecutor extends ActionExecutor {
         super.initActionType();
         maxLen = getOozieConf().getInt(CallbackServlet.CONF_MAX_DATA_LEN, 2 * 1024);
         allowSshUserAtHost = ConfigurationService.getBoolean(CONF_SSH_ALLOW_USER_AT_HOST);
+        
+        String portId = getOozieConf().get(COMMAND_BASE_PORT, "22");
+        SSH_COMMAND_BASE += portId + " " +  SSH_COMMAND_OPTIONS;
+        SCP_COMMAND_BASE += portId + " " +  SSH_COMMAND_OPTIONS;
+        
         registerError(InterruptedException.class.getName(), ActionExecutorException.ErrorType.ERROR, "SH001");
         registerError(JDOMException.class.getName(), ActionExecutorException.ErrorType.ERROR, "SH002");
         initSshScripts();

--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -2366,5 +2366,14 @@
             it will only rerun through parent.
         </description>
     </property>
+    
+    <property>
+        <name>oozie.action.ssh.command.port</name>
+        <value>22</value>
+        <description>
+            Due to linux ssh port will be change, and the default value is 22.
+            You can change to any value in your cluster
+        </description>
+    </property>
 
 </configuration>


### PR DESCRIPTION
I failed to run ssh action for our linux server's ssh port is not 22. 
so we add a config property in oozie-site.xml to let user configure ssh port.