### PR TITLE
Add support for s3/s3n schemes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -370,6 +370,12 @@
             <artifactId>hive-jdbc</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.10.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/apache/oozie/dependency/S3URIHandler.java
+++ b/core/src/main/java/org/apache/oozie/dependency/S3URIHandler.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.oozie.dependency;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.oozie.ErrorCode;
+import org.apache.oozie.action.hadoop.LauncherURIHandler;
+import org.apache.oozie.action.hadoop.S3LauncherURIHandler;
+import org.apache.oozie.dependency.s3.S3Utils;
+import org.apache.oozie.util.XLog;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+public class S3URIHandler implements URIHandler {
+
+    private static final XLog LOG = XLog.getLog(S3URIHandler.class);
+    private static final Set<String> SUPPORTED_SCHEMES = Sets.newHashSet("s3", "s3n");
+
+    // private AWSCredentials awsCredentials;
+    private List<Class<?>> classesToShip;
+
+    @Override
+    public void init(Configuration conf)
+    {
+        /*
+        LOG.info("Reading AWS credentials from Configuration file");
+
+        final String awsAccessKeyId = conf.get(S3Utils.AWS_ACCESS_KEY_ID);
+        final String awsSecretKey = conf.get(S3Utils.AWS_SECRET_KEY);
+
+        Preconditions.checkArgument(!awsAccessKeyId.isEmpty());
+        Preconditions.checkArgument(!awsSecretKey.isEmpty());
+
+        awsCredentials = new BasicAWSCredentials(awsAccessKeyId, awsSecretKey);
+        */
+        classesToShip = new S3LauncherURIHandler().getClassesForLauncher();
+    }
+
+    @Override
+    public Set<String> getSupportedSchemes()
+    {
+        return SUPPORTED_SCHEMES;
+    }
+
+    @Override
+    public Class<? extends LauncherURIHandler> getLauncherURIHandlerClass()
+    {
+        return S3LauncherURIHandler.class;
+    }
+
+    @Override
+    public List<Class<?>> getClassesForLauncher()
+    {
+        return classesToShip;
+    }
+
+    @Override
+    public DependencyType getDependencyType(URI uri)
+        throws URIHandlerException
+    {
+        return DependencyType.PULL;
+    }
+
+    @Override
+    public void registerForNotification(URI uri, Configuration conf, String user, String actionID)
+        throws URIHandlerException
+    {
+        throw new UnsupportedOperationException("Notifications are not supported for " + uri.getScheme());
+    }
+
+    @Override
+    public boolean unregisterFromNotification(URI uri, String actionID)
+    {
+        throw new UnsupportedOperationException("Notifications are not supported for " + uri.getScheme());
+    }
+
+    @Override
+    public Context getContext(URI uri, Configuration conf, String user, boolean readOnly)
+        throws URIHandlerException
+    {
+        return new S3Context(conf, user);
+    }
+
+    @Override
+    public boolean exists(URI uri, Context context)
+        throws URIHandlerException
+    {
+        return S3Utils.exists(
+            S3Utils.getAmazonS3URI(uri),
+            ((S3Context) context).getAmazonS3()
+        );
+    }
+
+    @Override
+    public boolean exists(URI uri, Configuration conf, String user)
+        throws URIHandlerException
+    {
+        return S3Utils.exists(
+            S3Utils.getAmazonS3URI(uri),
+            ((S3Context) getContext(S3Utils.getNormalizedURI(uri), conf, user, true)).getAmazonS3()
+        );
+    }
+
+    @Override
+    public void delete(URI uri, Context context)
+        throws URIHandlerException
+    {
+        try
+        {
+            final AmazonS3URI amazonS3URI = S3Utils.getAmazonS3URI(uri);
+            final AmazonS3 amazonS3 = ((S3Context) context).getAmazonS3();
+
+            if (uri.getPath().endsWith("/"))    // this is a directory
+            {
+                LOG.debug("Removing S3 directory [{0}]", amazonS3URI.toString());
+
+                ObjectListing fileList = amazonS3.listObjects(amazonS3URI.getBucket(), amazonS3URI.getKey());
+                // remove all files in folder
+                for (S3ObjectSummary file : fileList.getObjectSummaries())
+                {
+                    amazonS3.deleteObject(amazonS3URI.getBucket(), file.getKey());
+                }
+                amazonS3.deleteObject(amazonS3URI.getBucket(), amazonS3URI.getKey());   // remove folder
+            }
+            else
+            {
+                // remove single object
+                LOG.debug("Removing S3 object [{0}]", amazonS3URI.toString());
+
+                amazonS3.deleteObject(amazonS3URI.getBucket(), amazonS3URI.getKey());
+            }
+        }
+        catch (AmazonS3Exception ex)
+        {
+            LOG.error(ex);
+
+            throw new URIHandlerException(ErrorCode.E0907, uri);
+        }
+    }
+
+    @Override
+    public void delete(URI uri, Configuration conf, String user)
+        throws URIHandlerException
+    {
+        final URI normalizedURI = S3Utils.getNormalizedURI(uri);
+        delete(normalizedURI, getContext(normalizedURI, conf, user, false));
+    }
+
+    @Override
+    public String getURIWithDoneFlag(String uri, String doneFlag)
+        throws URIHandlerException
+    {
+        if (doneFlag.length() > 0) {
+            uri += "/" + doneFlag;
+        }
+        return uri;
+    }
+
+    @Override
+    public void validate(String uri)
+        throws URIHandlerException
+    {
+        // do nothing
+    }
+
+    @Override
+    public void destroy()
+    {
+        // do nothing
+    }
+
+    static class S3Context extends Context {
+
+        private final AmazonS3Client amazonS3;
+
+        /**
+         * Create a S3Context that can be used to access an S3 URI
+         *
+         * @param conf Configuration to access the URI
+         * @param user name of the user the URI should be accessed as
+         */
+        public S3Context(Configuration conf, String user) {
+            super(conf, user);
+
+            amazonS3 = new AmazonS3Client();
+            Preconditions.checkNotNull(amazonS3);
+        }
+
+        public AmazonS3Client getAmazonS3()
+        {
+            return amazonS3;
+        }
+    }
+}

--- a/core/src/main/java/org/apache/oozie/dependency/s3/S3Utils.java
+++ b/core/src/main/java/org/apache/oozie/dependency/s3/S3Utils.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.oozie.dependency.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.apache.oozie.ErrorCode;
+import org.apache.oozie.dependency.URIHandlerException;
+import org.apache.oozie.util.XLog;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class S3Utils
+{
+    private static final XLog LOG = XLog.getLog(S3Utils.class);
+
+    /*
+    public static final String AWS_ACCESS_KEY_ID = "AWSAccessKeyId";
+    public static final String AWS_SECRET_KEY = "AWSSecretKey";
+    */
+
+    static public URI getNormalizedURI(URI uri)
+        throws URIHandlerException
+    {
+        String scheme = uri.getScheme().substring(0, 2).toLowerCase();
+        if (scheme.compareTo("s3") != 0)
+        {
+            throw new URIHandlerException(ErrorCode.E0906, uri.toString());
+        }
+
+        try
+        {
+            return new URI(scheme + "://" + uri.getHost() + uri.getPath().replace("//", "/"));
+        }
+        catch (URISyntaxException ex)
+        {
+            throw new URIHandlerException(ErrorCode.E0906, uri.toString());
+        }
+    }
+
+    static public AmazonS3URI getAmazonS3URI(URI uri)
+        throws URIHandlerException
+    {
+        return new AmazonS3URI(getNormalizedURI(uri));
+    }
+
+    static private boolean doesMatch(String commonPrefix, String targetPrefix)
+    {
+        return commonPrefix.compareTo(targetPrefix) == 0;
+    }
+
+    static public boolean exists(AmazonS3URI amazonS3URI, AmazonS3 amazonS3)
+    {
+        LOG.trace("boolean S3URIHandler::exists([{0}], [{1}])", amazonS3URI.toString(), amazonS3.getClass().toString());
+
+        final String targetPrefix = amazonS3URI.getKey();
+
+        final ObjectListing objectListing = amazonS3
+            .listObjects(
+                new ListObjectsRequest()
+                    .withBucketName(amazonS3URI.getBucket())
+                    .withPrefix(targetPrefix.endsWith("/") ? targetPrefix.substring(0, targetPrefix.length() - 1) : targetPrefix)
+                    .withDelimiter("/")
+            );
+
+        for (String commonPrefix : objectListing.getCommonPrefixes())
+        {
+            if (doesMatch(commonPrefix, targetPrefix))
+            {
+                LOG.debug("Found match for [{0}] in prefix [{1}]", amazonS3URI.toString(), commonPrefix);
+                return true;
+            }
+        }
+
+        for (S3ObjectSummary summary : objectListing.getObjectSummaries())
+        {
+            if (doesMatch(summary.getKey(), targetPrefix))
+            {
+                LOG.debug("Found match for [{0}] in S3ObjectSummary [{1}]", amazonS3URI.toString(), summary.getKey());
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -2108,7 +2108,7 @@
 
     <property>
         <name>oozie.service.URIHandlerService.uri.handlers</name>
-        <value>org.apache.oozie.dependency.FSURIHandler</value>
+        <value>org.apache.oozie.dependency.FSURIHandler,org.apache.oozie.dependency.S3URIHandler</value>
         <description>
                 Enlist the different uri handlers supported for data availability checks.
         </description>

--- a/core/src/test/java/org/apache/oozie/dependency/s3/TestS3Utils.java
+++ b/core/src/test/java/org/apache/oozie/dependency/s3/TestS3Utils.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.oozie.dependency.s3;
+
+import com.amazonaws.services.s3.AmazonS3URI;
+import junit.framework.TestCase;
+import org.apache.oozie.dependency.URIHandlerException;
+
+import java.net.URI;
+
+public class TestS3Utils
+    extends TestCase
+{
+    public void testGetNormalizedURI_1()
+        throws Exception
+    {
+        URI uri = S3Utils.getNormalizedURI(new URI("s3n://my-bucket//my-folder//2015/01/01//"));
+
+        assertEquals(uri.toString(), "s3://my-bucket/my-folder/2015/01/01/");
+        assertEquals(uri.getScheme(), "s3");
+        assertEquals(uri.getHost(), "my-bucket");
+        assertEquals(uri.getPath(), "/my-folder/2015/01/01/");
+
+        System.out.println(uri.toString());
+    }
+
+    public void testGetNormalizedURI_2()
+        throws Exception
+    {
+        try
+        {
+            URI uri = S3Utils.getNormalizedURI(new URI("s2n://my-bucket//my-folder//2015/01/01//"));
+
+            assertTrue("This test should throw, but it didn't", false);
+        }
+        catch (URIHandlerException ex)
+        {
+            assertTrue(true);
+        }
+    }
+
+    public void testGetAmazonS3URI_1()
+        throws Exception
+    {
+        AmazonS3URI uri = S3Utils.getAmazonS3URI(new URI("s3n://my-bucket//my-folder//2015/01/01//"));
+
+        assertEquals(uri.toString(), "s3://my-bucket/my-folder/2015/01/01/");
+        assertEquals(uri.getBucket(), "my-bucket");
+
+        // PLEASE: not the difference between getKey on AmazonS3URI and getPath() on a standard URI
+        assertEquals(uri.getKey(), "my-folder/2015/01/01/");
+
+        System.out.println(uri.toString());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -142,13 +142,6 @@
             </snapshots>
         </repository>
         <repository>
-            <id>Codehaus repository</id>
-            <url>http://repository.codehaus.org/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>apache.snapshots.repo</id>
             <url>https://repository.apache.org/content/groups/snapshots</url>
             <name>Apache Snapshots Repository</name>

--- a/sharelib/oozie/src/main/java/org/apache/oozie/action/hadoop/S3LauncherURIHandler.java
+++ b/sharelib/oozie/src/main/java/org/apache/oozie/action/hadoop/S3LauncherURIHandler.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.oozie.action.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URI;
+import java.util.List;
+
+public class S3LauncherURIHandler implements LauncherURIHandler
+{
+    // TODO
+    @Override
+    public boolean create(URI uri, Configuration conf)
+        throws LauncherException
+    {
+        throw new UnsupportedOperationException("Creating directory at is not supported for " + uri);
+    }
+
+    // TODO
+    @Override
+    public boolean delete(URI uri, Configuration conf)
+        throws LauncherException
+    {
+        throw new UnsupportedOperationException("Deleting directory at is not supported for " + uri);
+    }
+
+    @Override
+    public List<Class<?>> getClassesForLauncher()
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
The idea is to create a new URIHandler, that uses AWS S3 SDK to check existence of data in S3. Credentials are taken from the IAM Role of the EC2 instance (hence no need of configuration), but I am planning of extending to support custom AWS credential in the oozie-core.xml file.

This patch is particularly useful with Amazon Elastic MapReduce (EMR), because no credentials are stored in the core-site.xml in that case (as EMR will use the custom EmrFileSystem to access S3).

I am a bit unsure about the need of the S3LauncherURIHandler, so I made the methods throw and UnsupportedOperationException, but I would be happy to fill the gap here as well.
