### PR TITLE
*.so files with fragments are saved with wrong names

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
@@ -551,11 +551,7 @@ public class JavaActionExecutor extends ActionExecutor {
             }
             else {
                 String fileName = filePath.substring(filePath.lastIndexOf("/") + 1);
-                if (fileName.endsWith(".so") || fileName.contains(".so.")) { // .so files
-                    uri = new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), uri.getQuery(), fileName);
-                    DistributedCache.addCacheFile(uri.normalize(), conf);
-                }
-                else if (fileName.endsWith(".jar")) { // .jar files
+                if (fileName.endsWith(".jar")) { // .jar files
                     if (!fileName.contains("#")) {
                         String user = conf.get("user.name");
                         Path pathToAdd = new Path(uri.normalize());

--- a/core/src/test/java/org/apache/oozie/action/hadoop/TestJavaActionExecutor.java
+++ b/core/src/test/java/org/apache/oozie/action/hadoop/TestJavaActionExecutor.java
@@ -2238,6 +2238,7 @@ public class TestJavaActionExecutor extends ActionExecutorTestCase {
         conf.clear();
         ae.addToCache(conf, appPath, appSoFragmentFullPath.toString(), false);
         assertTrue(conf.get("mapred.cache.files").contains(appSoFragmentFullPath.toString()));
+        assertTrue(Arrays.asList(conf.get("mapred.cache.files").split(",")).contains(appSoFragmentFullPath.toString()));
         assertTrue(DistributedCache.getSymlink(conf));
 
         // test .jar without fragment where app path is on same cluster as jar path


### PR DESCRIPTION
JavaActionExecutor.addToCache checks if fileName contains "#" for every file type but *.so.