### PR TITLE
OOZIE-2571 Add scala.binary.version Maven property so that Scala 2.11 can be used

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -112,7 +112,7 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.10</artifactId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
          <curator.version>2.5.0</curator.version>
          <jackson.version>1.8.8</jackson.version>
          <log4j.version>1.2.17</log4j.version>
+         <scala.binary.version>2.10</scala.binary.version>
     </properties>
 
     <modules>

--- a/sharelib/spark/pom.xml
+++ b/sharelib/spark/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.10</artifactId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
             <exclusions>
@@ -105,13 +105,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-graphx_2.10</artifactId>
+            <artifactId>spark-graphx_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_2.10</artifactId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
             <exclusions>
@@ -171,43 +171,43 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.10</artifactId>
+            <artifactId>spark-mllib_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-repl_2.10</artifactId>
+            <artifactId>spark-repl_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.10</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming_2.10</artifactId>
+            <artifactId>spark-streaming_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming-flume_2.10</artifactId>
+            <artifactId>spark-streaming-flume_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming-kafka_2.10</artifactId>
+            <artifactId>spark-streaming-kafka_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-bagel_2.10</artifactId>
+            <artifactId>spark-bagel_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>compile</scope>
         </dependency>
@@ -327,7 +327,7 @@
             <dependencies>
                 <dependency>
                     <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-yarn_2.10</artifactId>
+                    <artifactId>spark-yarn_${scala.binary.version}</artifactId>
                     <version>${spark.version}</version>
                     <scope>compile</scope>
                     <exclusions>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/OOZIE-2571

The pom.xml files hardcode a Scala binary version of Scala 2.10 for its Spark dependencies, making it impossible to use a version of Spark built against Scala 2.11.