### PR TITLE
extjs filter that leads to replay attacks problems

### DIFF
--- a/distro/src/main/tomcat/ssl-web.xml
+++ b/distro/src/main/tomcat/ssl-web.xml
@@ -257,11 +257,6 @@
 
     <filter-mapping>
         <filter-name>authenticationfilter</filter-name>
-        <url-pattern>/ext-2.2/*</url-pattern>
-    </filter-mapping>
-
-    <filter-mapping>
-        <filter-name>authenticationfilter</filter-name>
         <url-pattern>/docs/*</url-pattern>
     </filter-mapping>
 


### PR DESCRIPTION
Remove the filter which causes double work on the KDC and leads to replay attacks and a non working oozie ui when in a kerberos aware browser against a kerberos cluster.