### PR TITLE
Updated clover2 plugin to conform with it's new name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <failIfNoTests>false</failIfNoTests>
 
         <test.timeout>5400</test.timeout>
-        <clover.version>4.0.6</clover.version>
+        <clover.version>4.1.1</clover.version>
         <!-- platform encoding override -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1705,7 +1705,7 @@
         <plugins>
             <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>
-                <artifactId>maven-clover2-plugin</artifactId>
+                <artifactId>clover-maven-plugin</artifactId> <!-- maven-clover2-plugin before 4.1.1 -->
                 <version>${clover.version}</version>
                 <configuration>
                     <licenseLocation>${clover.license}</licenseLocation>


### PR DESCRIPTION
Atlassian has recently changed the name of clover2 plugin. To avoid warnings while building oozie it's necessary to fix it's path.

https://confluence.atlassian.com/clover/what-happened-to-maven-clover2-plugin-792634162.html

