### PR TITLE
[OOZIE-3566] Wrong numbers provided by Oozie monitoring webservices.requests sampler.

### DIFF
--- a/core/src/main/java/org/apache/oozie/servlet/JsonRestServlet.java
+++ b/core/src/main/java/org/apache/oozie/servlet/JsonRestServlet.java
@@ -295,11 +295,11 @@ public abstract class JsonRestServlet extends HttpServlet {
         requestCron.set(cron);
         try {
             cron.start();
+            TOTAL_REQUESTS_SAMPLER_COUNTER.incrementAndGet();
+            samplerCounter.incrementAndGet();
             validateRestUrl(request.getMethod(), getResourceName(request), request.getParameterMap());
             XLog.Info.get().clear();
             String user = getUser(request);
-            TOTAL_REQUESTS_SAMPLER_COUNTER.incrementAndGet();
-            samplerCounter.incrementAndGet();
             //If trace is enabled then display the request headers
             XLog log = XLog.getLog(getClass());
             if (log.isTraceEnabled()){


### PR DESCRIPTION
`org.apache.oozie.servlet.JsonRestServlet.TOTAL_REQUESTS_SAMPLER_COUNTER` and `org.apache.oozie.servlet.JsonRestServlet.samplerCounter` now incremented before call to `org.apache.oozie.servlet.JsonRestServlet.validateRestUrl` which doesnt allow counters to be decremented without being incremented before.