### PR TITLE
OOZIE-3362 When killed, SSH action should kill the spawned processes …

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/ssh/SshActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/ssh/SshActionExecutor.java
@@ -220,7 +220,7 @@ public class SshActionExecutor extends ActionExecutor {
     @Override
     public void kill(Context context, WorkflowAction action) throws ActionExecutorException {
         LOG.info("Killing action");
-        String command = "ssh " + action.getTrackerUri() + " kill  -KILL " + action.getExternalId();
+        String command = "ssh " + action.getTrackerUri() + " kill --  -$(ps -o pgid= " + action.getExternalId() + " | grep -o [0-9]*)";
         int returnValue = getReturnValue(command);
         if (returnValue != 0) {
             throw new ActionExecutorException(ActionExecutorException.ErrorType.ERROR, "FAILED_TO_KILL", XLog.format(


### PR DESCRIPTION
When the SSH action is terminated via the kill API, only the ssh-wrapper.sh file (created for ssh execution in oozie) is terminated, and the child-processes that has occurred is still running.

For example, if the shell file for running spark-shell (e.g. called "run-spark.sh") runs and exits as an SSH action, only the ssh-wrapper.sh file exits and the child-processes (run-spark.sh and spark-shell) are still running.

Therefore, when the SSH action is killed, it must be changed to the kill command that can terminate the related subprocess.