### PR TITLE
[OOZIE-3601] Bump quartz.version from 2.3.1 to 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1530,7 +1530,7 @@
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
-                <version>2.3.1</version>
+                <version>2.3.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
for [https://issues.apache.org/jira/browse/OOZIE-3601](https://issues.apache.org/jira/browse/OOZIE-3601)

https://nvd.nist.gov/vuln/detail/CVE-2019-13990