### PR TITLE
Fix OOZIE-3620: hadoopId is not sent to listener for workflow action events

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/wf/WorkflowXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/WorkflowXCommand.java
@@ -85,6 +85,7 @@ public abstract class WorkflowXCommand<T> extends XCommand<T> {
                     wfAction.getStatus(), wfUser, wfAction.getName(), wfAction.getStartTime(), wfAction.getEndTime());
             event.setErrorCode(wfAction.getErrorCode());
             event.setErrorMessage(wfAction.getErrorMessage());
+            event.setHadoopId(wfAction.getExternalId());
             getEventService().queueEvent(event);
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/OOZIE-3620

Not sure if you accept PRs yet or if my JIRA patch is the right way to do it.