### PR TITLE
[OOZIE-3622] No mapreduce jars in the classpath for hadoop3 mapreduce job

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/hadoop/MapReduceActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/MapReduceActionExecutor.java
@@ -474,6 +474,13 @@ public class MapReduceActionExecutor extends JavaActionExecutor {
         }
     }
 
+    @Override
+    protected void addActionSpecificEnvVars(Map<String, String> env) {
+        // need to specify HADOOP_MAPRED_HOME for hadoop3, otherwise mapreduce jars won't be included
+        // in the launcher's CLASSPATH.
+        env.put("HADOOP_MAPRED_HOME", "${HADOOP_HOME}");
+    }
+
     /**
      * Finds a Hadoop job ID based on {@code action-data.seq} file stored on HDFS by {@link MapReduceMain}.
      */


### PR DESCRIPTION
 The mapreduce job example in oozie doesn't work due to mapreduce jars won't be included in the classpath, This PR is to add `HADOOP_MAPRED_HOME ` to mapreduce action's launcher jvm's environment.