### PR TITLE
OOZIE-3639 Bump snappy-java to 1.1.8.4 for Linux ARM64 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
          <pig.version>0.16.0</pig.version>
          <pig.classifier>h2</pig.classifier>
          <hive.classifier>core</hive.classifier>
+         <snappy-java.version>1.1.8.4</snappy-java.version>
          <sqoop.version>1.4.7</sqoop.version>
          <spark.version>1.6.1</spark.version>
          <spark.streaming.kafka.version>1.6.1</spark.streaming.kafka.version>
@@ -336,6 +337,12 @@
                 <artifactId>junit</artifactId>
                 <version>4.11</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy-java.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Define a dependencyManagement for snappy-java, so that sharelib/spark uses its latest version that supports Linux aarch64.