### PR TITLE
[OOZIE-3646] Possible dead-lock in SignalXCommand

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/wf/SignalXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/SignalXCommand.java
@@ -468,21 +468,52 @@ public class SignalXCommand extends WorkflowXCommand<Void> {
 
     public void startForkedActions(List<WorkflowActionBean> workflowActionBeanListForForked) throws CommandException {
 
-        List<CallableWrapper<ActionExecutorContext>> tasks = new ArrayList<CallableWrapper<ActionExecutorContext>>();
         List<UpdateEntry> updateList = new ArrayList<UpdateEntry>();
         List<JsonBean> insertList = new ArrayList<JsonBean>();
 
         boolean endWorkflow = false;
         boolean submitJobByQueuing = false;
-        for (WorkflowActionBean workflowActionBean : workflowActionBeanListForForked) {
-            LOG.debug("Starting forked actions parallely : " + workflowActionBean.getId());
-            tasks.add(Services.get().get(CallableQueueService.class).new CallableWrapper<ActionExecutorContext>(
-                    new ForkedActionStartXCommand(wfJob, workflowActionBean.getId(), workflowActionBean.getType()), 0));
-        }
 
         try {
-            List<Future<ActionExecutorContext>> futures = Services.get().get(CallableQueueService.class)
-                    .invokeAll(tasks);
+            /*
+             * The limited thread execution mechanism aims to solve the dead-lock when all active threads are
+             * executing the SignalXCommand's invokeAll method.
+             *
+             * Solution
+             * 1. Need to limit directly invokeAll call when the num of rest threads is less than the tasks
+             * 2. To obtain correct active threads number in callableQueue, the SignalXCommand.class lock is needed.
+             *
+             */
+            CallableQueueService callableQueueService = Services.get().get(CallableQueueService.class);
+            List<Future<ActionExecutorContext>> futures = new ArrayList<>();
+
+            synchronized (SignalXCommand.class) {
+                long limitedRestThreadNum = callableQueueService.getQueueThreadsNumber() - callableQueueService.getThreadActiveCount();
+                if (limitedRestThreadNum < workflowActionBeanListForForked.size()) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Limited callable queue rest threads number: " + limitedRestThreadNum + ", needed forked task size: "
+                                + workflowActionBeanListForForked.size() + ", tasks will be submitted to queue by async mode.");
+                    }
+                    submitJobByQueuing = true;
+                } else {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Starting forked actions parallely: " + workflowActionBeanListForForked);
+                    }
+                    for (WorkflowActionBean workflowActionBean : workflowActionBeanListForForked) {
+                        futures.add(
+                                callableQueueService.submit(callableQueueService.new CallableWrapper<ActionExecutorContext>(
+                                        new ForkedActionStartXCommand(wfJob, workflowActionBean.getId(), workflowActionBean.getType()), 0))
+                        );
+                    }
+
+                    long startTime = System.currentTimeMillis();
+                    callableQueueService.blockingWait(futures);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Execution time of forked actions parallely: " + (System.currentTimeMillis() - startTime) / 1000 + " sec");
+                    }
+                }
+            }
+
             for (Future<ActionExecutorContext> result : futures) {
                 if (result == null) {
                     submitJobByQueuing = true;

--- a/core/src/test/java/org/apache/oozie/command/wf/TestSignalXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/wf/TestSignalXCommand.java
@@ -19,12 +19,18 @@
 package org.apache.oozie.command.wf;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Appender;
@@ -37,8 +43,11 @@ import org.apache.oozie.WorkflowActionBean;
 import org.apache.oozie.client.OozieClient;
 import org.apache.oozie.client.WorkflowAction;
 import org.apache.oozie.client.WorkflowJob;
+import org.apache.oozie.executor.jpa.WorkflowJobQueryExecutor;
 import org.apache.oozie.local.LocalOozie;
+import org.apache.oozie.service.CallableQueueService;
 import org.apache.oozie.service.ConfigurationService;
+import org.apache.oozie.service.ExtendedCallableQueueService;
 import org.apache.oozie.service.Services;
 import org.apache.oozie.test.XDataTestCase;
 import org.apache.oozie.util.IOUtils;
@@ -313,5 +322,89 @@ public class TestSignalXCommand extends XDataTestCase {
         }
         assertEquals(prepActions.length, numPrep);
         assertEquals(okActions.length, numOK);
+    }
+
+    private void writeToFile(String appXml, String appPath) throws IOException {
+        File wf = new File(URI.create(appPath));
+        try(PrintWriter out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(wf), StandardCharsets.UTF_8))) {
+            out.println(appXml);
+        }
+    }
+
+    /*
+     *  This test case is just to test possible dead-lock when
+     *  the conf of oozie.workflow.parallel.fork.action.start
+     *  is enabled.
+     *
+     *  Details could be linked to OOZIE-3646
+     */
+    public void testPossibleDeadLock() throws Exception {
+        setSystemProperty(Services.CONF_SERVICE_EXT_CLASSES, ExtendedCallableQueueService.class.getName());
+
+        services = new Services();
+        Configuration servicesConf = services.getConf();
+        servicesConf.setInt(CallableQueueService.CONF_THREADS, 1);
+        services.init();
+
+        ConfigurationService.setBoolean(SignalXCommand.FORK_PARALLEL_JOBSUBMISSION, true);
+
+        Configuration conf = new XConfiguration();
+        String workflowUri = getTestCaseFileUri("workflow.xml");
+        //@formatter:off
+        String appXml = "<workflow-app xmlns=\"uri:oozie:workflow:0.4\" name=\"wf-fork\">"
+                + "<start to=\"fork1\"/>"
+                + "<fork name=\"fork1\">"
+                + "<path start=\"action1\"/>"
+                + "<path start=\"action2\"/>"
+                + "<path start=\"action3\"/>"
+                + "<path start=\"action4\"/>"
+                + "<path start=\"action5\"/>"
+                + "</fork>"
+                + "<action name=\"action1\">"
+                + "<fs></fs>"
+                + "<ok to=\"join1\"/>"
+                + "<error to=\"kill\"/>"
+                + "</action>"
+                + "<action name=\"action2\">"
+                + "<fs></fs><ok to=\"join1\"/>"
+                + "<error to=\"kill\"/>"
+                + "</action>"
+                + "<action name=\"action3\">"
+                + "<fs></fs><ok to=\"join1\"/>"
+                + "<error to=\"kill\"/>"
+                + "</action>"
+                + "<action name=\"action4\">"
+                + "<fs></fs><ok to=\"join1\"/>"
+                + "<error to=\"kill\"/>"
+                + "</action>"
+                + "<action name=\"action5\">"
+                + "<fs></fs><ok to=\"join1\"/>"
+                + "<error to=\"kill\"/>"
+                + "</action>"
+                + "<join name=\"join1\" to=\"end\"/>"
+                + "<kill name=\"kill\"><message>killed</message>"
+                + "</kill><"
+                + "end name=\"end\"/>"
+                + "</workflow-app>";
+        //@Formatter:on
+
+        writeToFile(appXml, workflowUri);
+        conf.set(OozieClient.APP_PATH, workflowUri);
+        conf.set(OozieClient.USER_NAME, getTestUser());
+
+        SubmitXCommand sc = new SubmitXCommand(conf);
+        final String jobId = sc.call();
+        new StartXCommand(jobId).call();
+
+        waitFor(20 * 1000, new Predicate() {
+            @Override
+            public boolean evaluate() throws Exception {
+                return WorkflowJobQueryExecutor.getInstance().get(WorkflowJobQueryExecutor.WorkflowJobQuery.GET_WORKFLOW, jobId).getStatus()
+                        == WorkflowJob.Status.SUCCEEDED;
+            }
+        });
+
+        assertEquals(WorkflowJobQueryExecutor.getInstance().get(WorkflowJobQueryExecutor.WorkflowJobQuery.GET_WORKFLOW, jobId).getStatus(),
+                WorkflowJob.Status.SUCCEEDED);
     }
 }


### PR DESCRIPTION
The limited thread execution mechanism aims to solve the dead-lock when all active threads are executing the SignalXCommand's invokeAll method.

### Dead-lock when to happen
Assuming that Oozie CallableQueue thread pool size is 120, when all threads are executing the SignalXCommand.startForkedActions method, a deadlock occurs.
Because in SignalXCommand.startForkedActions, the code of {{List<Future<ActionExecutorContext>> futures = Services.get().get(CallableQueueService.class)
.invokeAll(tasks);}} will be sync executed, however now all callableQueue threads are busy.

### Solution
1. Need to limit directly invokeAll call when the num of rest threads is less than the tasks
2. To obtain correct active threads number in callableQueue, the SignalXCommand.class lock is needed.