### PR TITLE
[OOZIE-3650] upgrade to jackson 2.6.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
          <derby.version>10.14.2.0</derby.version>
          <xerces.version>2.11.0</xerces.version>
          <curator.version>2.5.0</curator.version>
-         <jackson.version>2.6.5</jackson.version>
+         <jackson.version>2.6.7.5</jackson.version>
          <log4j.version>1.2.17</log4j.version>
          <activemq.version>5.15.9</activemq.version>
          <commons.lang3.version>3.3.2</commons.lang3.version>


### PR DESCRIPTION
Has a few CVE fixes but is still very close to the version that Oozie currently supports.