### PR TITLE
[OOZIE-3659] Add variable and comments for an ambiguous port number in TestOozieCLI.java

### DIFF
--- a/core/src/test/java/org/apache/oozie/client/TestOozieCLI.java
+++ b/core/src/test/java/org/apache/oozie/client/TestOozieCLI.java
@@ -84,6 +84,7 @@ public class TestOozieCLI extends DagServletTestCase {
     static final String VERSION = "/v" + OozieClient.WS_PROTOCOL_VERSION;
     static final String[] END_POINTS = {"/versions", VERSION + "/jobs", VERSION + "/job/*", VERSION + "/admin/*",
             VERSION + "/validate/*", "/v1/sla"};
+    static final String INVALID_PORT = "11";
     static final Class<?>[] SERVLET_CLASSES = { HeaderTestingVersionServlet.class, V1JobsServlet.class,
             V2JobServlet.class, V2AdminServlet.class, V2ValidateServlet.class, SLAServlet.class};
 
@@ -1508,7 +1509,8 @@ public class TestOozieCLI extends DagServletTestCase {
             @Override
             public Void call() throws Exception {
                 HeaderTestingVersionServlet.OOZIE_HEADERS.clear();
-                String oozieUrl = "http://localhost:11/oozie";
+                // negative test with an invalid port to verify the no of retries in a timeout case
+                String oozieUrl = "http://localhost:" + INVALID_PORT + "/oozie";
                 String[] args = new String[] { "job", "-update", "aaa", "-dryrun", "-oozie", oozieUrl, "-debug" };
                 OozieCLI cli = new OozieCLI();
                 CLIParser parser = cli.getCLIParser();
@@ -1553,7 +1555,8 @@ public class TestOozieCLI extends DagServletTestCase {
             @Override
             public Void call() throws Exception {
                 HeaderTestingVersionServlet.OOZIE_HEADERS.clear();
-                String oozieUrl = "http://localhost:11/oozie";
+                // negative test with an invalid port to verify the no of retries
+                String oozieUrl = "http://localhost:" + INVALID_PORT + "/oozie";
                 String[] args = new String[] { "job", "-update", "aaa", "-dryrun", "-oozie", oozieUrl, "-debug" };
                 OozieCLI cli = new OozieCLI() {
                     protected void setRetryCount(OozieClient wc) {


### PR DESCRIPTION
Line 1511 and 1556: port number 11 of oozieUrl is ambiguous. It is an invalid port number intended for negative test cases. Comments and parameterization recommended.

https://github.com/apache/oozie/blob/f1e01a9e155692aa5632f4573ab1b3ebeab7ef45/core/src/test/java/org/apache/oozie/client/TestOozieCLI.java
