### PR TITLE
Fix fork out more than one transitions submit , one transition submit fail can't execute KillXCommand

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/wf/SignalXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/SignalXCommand.java
@@ -549,6 +549,9 @@ public class SignalXCommand extends WorkflowXCommand<Void> {
                 if (context.getJobStatus() != null && context.getJobStatus().equals(Job.Status.FAILED)) {
                     LOG.warn("Action has failed, failing job" + context.getAction().getId());
                     new ActionStartXCommand(context.getAction().getId(), null).failJob(context);
+                    // fixed fork out more than one transitions submit , one transition fail can't execute KillXCommand and other transitions still running
+                    queue(new WorkflowNotificationXCommand((WorkflowJobBean) context.getWorkflow(), (WorkflowActionBean) context.getAction()));
+                    queue(new KillXCommand(context.getWorkflow().getId()));
                     updateList.add(new UpdateEntry<WorkflowActionQuery>(WorkflowActionQuery.UPDATE_ACTION_START,
                             (WorkflowActionBean) context.getAction()));
                     if (context.isShouldEndWF()) {


### PR DESCRIPTION
When I fork 2 transitions( A and B)  to submit , when A fail , B still Running , because  can't execute KillXCommand.
      ActionXCommand execute failJob and add KillXCommand to commandQueue , but the commandQueue is the new Bean ActionXCommand not the SignalXCommand , so can't execute KillXCommand. The code is as follows



```java
new ActionStartXCommand(context.getAction().getId(), null).failJob(context)

public void failJob(ActionExecutor.Context context, WorkflowActionBean action) throws CommandException {
        WorkflowJobBean workflow = (WorkflowJobBean) context.getWorkflow();
        if (!handleUserRetry(context, action)) {
            incrActionErrorCounter(action.getType(), "failed", 1);
            LOG.warn("Failing Job due to failed action [{0}]", action.getName());
            try {
                workflow.getWorkflowInstance().fail(action.getName());
                WorkflowInstance wfInstance = workflow.getWorkflowInstance();
                ((LiteWorkflowInstance) wfInstance).setStatus(WorkflowInstance.Status.FAILED);
                workflow.setWorkflowInstance(wfInstance);
                workflow.setStatus(WorkflowJob.Status.FAILED);
                action.setStatus(WorkflowAction.Status.FAILED);
                action.resetPending();

                queue(new WorkflowNotificationXCommand(workflow, action));
                queue(new KillXCommand(workflow.getId()));

                InstrumentUtils.incrJobCounter(INSTR_FAILED_JOBS_COUNTER_NAME, 1, getInstrumentation());
            }
            catch (WorkflowException ex) {
                throw new CommandException(ex);
            }
        }
    }
```